### PR TITLE
ローカル開発用にLocalstackをdocker-composeで導入

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,13 @@
+version: "3.6"
+
+services:
+  localstack:
+    image: localstack/localstack
+    ports:
+      - "8080:8080"
+      - "4569:4569"
+      - "4574:4574"
+    environment:
+      - SERVICES=dynamodb,lambda
+      - DEFAULT_REGION=ap-northeast-1
+      - DOCKER_HOST=unix:///var/run/docker.sock


### PR DESCRIPTION
ローカル開発用にLocalstackをdocker-composeで導入する。

CircleCIのユニットテストでは↓こちらで対応している。
https://github.com/shoito/todo-app/blob/master/.circleci/config.yml#L11